### PR TITLE
Upload组件图片上传失败后uploading状态重置为false

### DIFF
--- a/components/Upload/Upload.jsx
+++ b/components/Upload/Upload.jsx
@@ -25,7 +25,7 @@ class Upload extends Component {
     }
   }
 
-  render () { 
+  render () {
     const props = this.props;
     const { multiple, fileExt, className, ...others } = props;
 
@@ -128,6 +128,7 @@ class Upload extends Component {
             this.setState({fileNumber});
           }
         } else {
+          this.setState({ uploading: false });
           onError();
         }
       }


### PR DESCRIPTION
如果不重置为false，失败一次后，点击上传会被直接return