### PR TITLE
修改Loading的render方法。避免在 切换 visible属性的时候再次创建children

### DIFF
--- a/components/Loading/index.tsx
+++ b/components/Loading/index.tsx
@@ -9,19 +9,16 @@ class Loading extends Component<PropsType, any> {
 
   render() {
     const { visible, children, style, prefixCls } = this.props;
-
-    return visible ? (
+    return (
       <div className={prefixCls} style={style}>
-        <div className={`${prefixCls}-spins`}>
+        <div className={`${prefixCls}-spins`} style={{ display: (visible ? 'block' : 'none') }}>
           <span className={`${prefixCls}-spin ${prefixCls}-spin-first`} />
           <span className={`${prefixCls}-spin ${prefixCls}-spin-second`} />
           <span className={`${prefixCls}-spin ${prefixCls}-spin-third`} />
         </div>
-        <div className={`${prefixCls}-inner`}>{children}</div>
+        <div className={visible ? `${prefixCls}-inner` : ''}>{children}</div>
       </div>
-    ) : (
-      children
-    );
+    )
   }
 }
 

--- a/examples/docs/loading.md
+++ b/examples/docs/loading.md
@@ -24,6 +24,10 @@
           显示
           </Button>
         </Loading>
+        <br />
+        <Button theme="info" onClick={() => this.toggleLoading()}>
+          隐藏
+        </Button>
       </div>
     )
   }


### PR DESCRIPTION
在Loading组件的children内部为组件时，切换visible状态会导致组件重复创建，带来一些性能上以及不可预见的问题。
修改为切换 visible状态只修改 className和 style属性。