### PR TITLE
修复SelectMultiple的样式问题

### DIFF
--- a/components/Select/SelectMultiple.tsx
+++ b/components/Select/SelectMultiple.tsx
@@ -104,7 +104,7 @@ class SelectMultiple extends Component<MultipleProps, any> {
       <span className={cls} style={style}>
         <span
           className={`${prefixCls}-selection`}
-          style={{ height: '100%' }}
+          style={{ height: '100%', maxHeight: 250, overflow: 'auto' }}
           role="combobox"
           aria-autocomplete="list"
           aria-haspopup="true"


### PR DESCRIPTION
- 限制SelectMultiple的高度，并设置overflow: 'auto'，修复选项溢出问题