### PR TITLE
将Table单元格内文字过长显示省略号和小浮层的行为设为可选

### DIFF
--- a/components/table/Cell.tsx
+++ b/components/table/Cell.tsx
@@ -11,7 +11,7 @@ class Cell extends Component<CellProps, any> {
       return null;
     }
     // 字符长度判断
-    if (typeof value === 'string' && value.length > maxCellSize) {
+    if (typeof value === 'string' && value.length > maxCellSize && maxCellSize !== 0) {
       return (
         <td
           key={column.dataIndex + columnIndex}
@@ -51,7 +51,7 @@ class Cell extends Component<CellProps, any> {
       return this.renderMergedCell(column, columnIndex, render);
     }
     // 字符长度判断
-    if (typeof render === 'string' && render.length > maxCellSize) {
+    if (typeof render === 'string' && render.length > maxCellSize && maxCellSize !== 0) {
       return (
         <td key={column.dataIndex + columnIndex} style={style}>
           <Popover trigger="hover" direction="top" content={render}>


### PR DESCRIPTION
1. 将Table单元格内文字过长显示省略号和小浮层的行为设为可选