### PR TITLE
fix: use React.Children.count to check if children is empty

### DIFF
--- a/components/swipe/index.tsx
+++ b/components/swipe/index.tsx
@@ -76,7 +76,7 @@ class Swipe extends Component<PropsType, any> {
   }
 
   parseItem(children) {
-    if (children.length === 0) {
+    if (React.Children.count(children) === 0) {
       return;
     }
 


### PR DESCRIPTION
1. 修复Swipe组件中children使用方式可能引起的JS报错