### PR TITLE
fix: get correct visible from state or props

### DIFF
--- a/components/dropdown/Dropdown.tsx
+++ b/components/dropdown/Dropdown.tsx
@@ -128,7 +128,7 @@ export default class Dropdown extends React.Component<DropdownProps, DropdownSta
   };
 
   onKeydown: KeyboardEventHandler = (e) => {
-    const { visible } = this.props;
+    const visible = getVisible(this.props, this.state);
     if (visible && e.keyCode === 27) {
       e.stopPropagation();
       if (this.popperContenRef.current && this.popperContenRef.current.contains(e.currentTarget)) {


### PR DESCRIPTION
修复了按esc按键的时候 获取visible不正确的问题