### PR TITLE
完善国际化组件使用方式

### DIFF
--- a/components/alert/Alert.tsx
+++ b/components/alert/Alert.tsx
@@ -13,13 +13,12 @@ class Alert extends Component<AlertProps, any> {
     className: '',
     hideIcon: false,
     closable: true,
-    // closeText: '关闭',
     onClose: () => {},
   };
 
   render() {
     const {
-      theme, message, closable, closeText, onClose, width,
+      theme, message, closable, cancelText, onClose, width,
       className, visible, prefixCls, hideIcon, locale,
     } = this.props;
 
@@ -52,7 +51,7 @@ class Alert extends Component<AlertProps, any> {
         {
           closable && (
             <Modal.Footer>
-              <Button onClick={onClose}>{closeText || locale!.close}</Button>
+              <Button onClick={onClose}>{cancelText || locale!.cancelText}</Button>
             </Modal.Footer>
           )
         }

--- a/components/alert/AlertInstance.tsx
+++ b/components/alert/AlertInstance.tsx
@@ -11,7 +11,7 @@ class AlertExtension extends Alert {
     const defalutValue = {
       width: 270,
       message: 'hello world',
-      closeText: '关闭',
+      cancelText: '关闭',
       hideIcon: false,
       theme: 'info',
       closable: true,
@@ -28,7 +28,7 @@ class AlertExtension extends Alert {
         width={object.width}
         visible={visible}
         message={object.message}
-        closeText={object.closeText}
+        cancelText={object.cancelText}
         hideIcon={object.hideIcon}
         onClose={() => {
           object.onClose();
@@ -37,7 +37,7 @@ class AlertExtension extends Alert {
         closable={object.closable}
         theme={object.theme}
         locale={{
-          close: 'close',
+          cancelText: 'Close',
         }}
       />,
       div,

--- a/components/alert/PropsType.tsx
+++ b/components/alert/PropsType.tsx
@@ -1,3 +1,5 @@
+import { Locale } from '../locale-provider/PropsType';
+
 export type themeType = 'default' | 'primary' | 'success' | 'warning' | 'danger';
 
 export default interface PropsType {
@@ -9,7 +11,7 @@ export default interface PropsType {
   visible?: boolean;
   hideIcon?: boolean;
   closable?: boolean;
-  closeText?: string;
-  locale?: { close: string };
+  cancelText?: string;
+  locale?: Locale['Alert'];
   onClose: () => void;
 }

--- a/components/alert/__tests__/__snapshots__/index.test.jsx.snap
+++ b/components/alert/__tests__/__snapshots__/index.test.jsx.snap
@@ -20,7 +20,7 @@ exports[`Alert renders basic Alert correctly 1`] = `
       hideIcon={false}
       locale={
         Object {
-          "close": "关闭",
+          "cancelText": "关闭",
         }
       }
       localeCode="zh-cn"

--- a/components/alert/locale/en_US.ts
+++ b/components/alert/locale/en_US.ts
@@ -1,0 +1,3 @@
+export default {
+  cancelText: 'Close',
+};

--- a/components/alert/locale/zh_CN.ts
+++ b/components/alert/locale/zh_CN.ts
@@ -1,0 +1,3 @@
+export default {
+  cancelText: '关闭',
+};

--- a/components/locale-provider/LocaleProvider.tsx
+++ b/components/locale-provider/LocaleProvider.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import LocaleProvider from 'zarm/lib/locale-provider';
-import defaultLocale from './lang/zh-cn';
+import defaultLocale from './locale/zh_CN';
 
 const LocaleProviderWrapper = ({ locale = defaultLocale, children }) => {
   return (

--- a/components/locale-provider/LocaleReceiver.tsx
+++ b/components/locale-provider/LocaleReceiver.tsx
@@ -1,5 +1,5 @@
 import LocaleReceiver from 'zarm/lib/locale-receiver';
-import defaultLocale from './lang/zh-cn';
+import defaultLocale from './locale/zh_CN';
 
 const LocaleReceiverWrapper = (componentName: any) => {
   return LocaleReceiver(componentName, defaultLocale as any);

--- a/components/locale-provider/PropsType.ts
+++ b/components/locale-provider/PropsType.ts
@@ -1,0 +1,7 @@
+import localeCN from './locale/zh_CN';
+
+export type Locale = typeof localeCN;
+
+export interface LocaleProviderProps {
+  locale: Locale;
+}

--- a/components/locale-provider/PropsType.ts
+++ b/components/locale-provider/PropsType.ts
@@ -1,7 +1,3 @@
 import localeCN from './locale/zh_CN';
 
 export type Locale = typeof localeCN;
-
-export interface LocaleProviderProps {
-  locale: Locale;
-}

--- a/components/locale-provider/demo.md
+++ b/components/locale-provider/demo.md
@@ -10,13 +10,13 @@ import { Alert, Button, LocaleProvider } from 'zarm-web';
 const localeCN = {
   locale: 'zh-cn',
   Alert: {
-    close: '关闭',
+    cancelText: '关闭',
   },
 }
 const localeEN = {
   locale: 'en',
   Alert: {
-    close: 'Close'
+    cancelText: 'Close'
   }
 }
 

--- a/components/locale-provider/locale/en_US.ts
+++ b/components/locale-provider/locale/en_US.ts
@@ -1,8 +1,8 @@
+import Alert from '../../alert/locale/en_US';
+
 export default {
   locale: 'en',
-  Alert: {
-    close: 'Close',
-  },
+  Alert,
   Calendar: {
     today: 'Today',
     now: 'Now',

--- a/components/locale-provider/locale/en_US.ts
+++ b/components/locale-provider/locale/en_US.ts
@@ -70,12 +70,4 @@ export default {
     confirm: 'Ok',
     clear: 'Clear',
   },
-  Notification: {
-    defaultTitles: {
-      error: 'Error',
-      success: 'Success',
-      warning: 'Warning',
-      default: 'Notification',
-    },
-  },
 };

--- a/components/locale-provider/locale/zh_CN.ts
+++ b/components/locale-provider/locale/zh_CN.ts
@@ -70,12 +70,4 @@ export default {
     clear: '清除',
     confirm: '确认',
   },
-  Notification: {
-    defaultTitles: {
-      error: '错误',
-      success: '成功',
-      warning: '警告',
-      default: '通知',
-    },
-  },
 };

--- a/components/locale-provider/locale/zh_CN.ts
+++ b/components/locale-provider/locale/zh_CN.ts
@@ -1,8 +1,8 @@
+import Alert from '../../alert/locale/zh_CN';
+
 export default {
   locale: 'zh-cn',
-  Alert: {
-    close: '关闭',
-  },
+  Alert,
   Calendar: {
     today: '今天',
     now: '此刻',


### PR DESCRIPTION
1. 完善了Alert组件使用国际化组件的示例
2. 目前已完成的组件不需要支持国际化，后续开发的组件如何做国际化可以参考Alert