### PR TITLE
fix: not trigger hidePop and rerender when click document and visible…

### DIFF
--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -53,7 +53,8 @@ class Popover extends Component<PropsType, any> {
   }
 
   onDocumentClick = (e: MouseEvent) => {
-    if (!this.instance || !this.pop) {
+    const { visible } = this.state;
+    if (!this.instance || !this.pop || !visible) {
       return;
     }
     if (e.target) {


### PR DESCRIPTION
当popover组件不显示的时候，点击document不触发更新，优化大量popover存在时候的性能问题。